### PR TITLE
Add token metadata: 3096 (3096...85d1)

### DIFF
--- a/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/info.json
+++ b/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/info.json
@@ -1,0 +1,10 @@
+{
+  "hash": "309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1",
+  "ticker": "3096",
+  "name": "Test 2",
+  "description": "Test 2",
+  "website": "",
+  "telegram": "",
+  "discord": "",
+  "twitter": ""
+}

--- a/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/logo.svg
+++ b/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/logo.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.8.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1080 1080" style="enable-background:new 0 0 1080 1080;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F8F8F9;}
+	.st1{fill:#FDB913;}
+	.st2{fill:#231F20;}
+	.st3{fill:#FFFFFF;}
+</style>
+<g id="Layer_1">
+</g>
+<g id="Layer_2">
+	<rect x="-44" y="-44" class="st1" width="1168" height="1168"/>
+	<g>
+		<polygon class="st2" points="291.1,784.1 376.1,785 455.8,682.5 359,719.5 		"/>
+		<g>
+			<path class="st2" d="M805.8,564l68.4-14.9l19.9-44.5l-26.5-6.4l-69.3-47.8l-52.8-86.9l-22.2,6.4l-21.3-62.3l-51,39.4l6.4-35.5
+				L565.2,295l30.3,26.4l-110.6-13.6l42.4,29.9L414,338.8l52.5,27l-99.4,21.8l51.8,13.1l-62.3,20.1l-1.9,0.1l-1.5,1L309,436l18,3.5
+				l-42.2,28.6l0.1-0.3l-42.3,26.9l-20.1,44.8l-36.5,18.7l6.3,17.6l47.3-13l26.5,26.7L268,665l-70.5,120h62.9l92.7-87l121.2-42.6
+				l124.2-61.8L726.1,624l24.8,51.2l62.6-29.7L783,591.3l-76.4-51.6l14.4-7.2L805.8,564z M761.7,429.8l10,25.5l-38.5-17.5
+				L761.7,429.8z"/>
+			<polygon class="st2" points="595.2,612.9 566.8,629.2 652.1,667.7 675.4,707.9 728.4,682.5 708.5,644.4 			"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Add token metadata for asset ticker `3096` (hash `3096...85d1`).

Submitted via [Warthog Asset Metadata](https://github.com/warthog-network/asset-metadata-js).
The `ticker` field is taken from the on-chain `AssetName` returned by the
defi node's `GET /asset/lookup/{hash}` endpoint.

Please review the field values below. The directory path will be
`data/assets/309655005d8a7a6cfe9871c9db0e1cc931a1e17732c00da28517d84cfdb385d1/` once this PR merges.

@warthog-asset-metadata[bot]
